### PR TITLE
fix iOS showShareSheet() linkProperties param being null

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -172,7 +172,7 @@ RCT_EXPORT_METHOD(
 ){
   dispatch_async(dispatch_get_main_queue(), ^(void){
     BranchUniversalObject *branchUniversalObject = [self createBranchUniversalObject:branchUniversalObjectMap];
-    BranchLinkProperties *linkProperties = [self createLinkProperties:linkProperties withControlParams:controlParamsMap];
+    BranchLinkProperties *linkProperties = [self createLinkProperties:linkPropertiesMap withControlParams:controlParamsMap];
     
     UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
     UIViewController *fromViewController = (rootViewController.presentedViewController ? rootViewController.presentedViewController : rootViewController);


### PR DESCRIPTION
just a lil' typo that resulted in `linkProperties` being null.
